### PR TITLE
DockerFile: Add g++ dependency & remove package dir deletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ ADD requirements.txt setup.py package/
 ADD vecino package/vecino
 
 RUN apt-get update && \
-    apt-get install -y --no-install-suggests --no-install-recommends ca-certificates git python3 python3-dev libxml2 libxml2-dev libonig2 make gcc curl && \
+    apt-get install -y --no-install-suggests --no-install-recommends ca-certificates git python3 python3-dev libxml2 libxml2-dev libonig2 make gcc curl g++ && \
     apt-get clean && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install --no-cache-dir -r package/requirements.txt && \
     apt-get remove -y python3-dev libxml2-dev make gcc curl && \
     apt-get autoremove -y
 
-RUN pip3 install --no-cache-dir ./package && rm -rf package
+RUN pip3 install --no-cache-dir ./package && rm -f package/requirements.txt && rm -f package/setup.py
 
 ENTRYPOINT ["vecino"]


### PR DESCRIPTION
# **What this PR does / why we need it:**

1. Add g++ dependency to avoid build error:
`g++ -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -Ibblfsh/libuast/ -I/usr/local/include -I/usr/local/include/libxml2 -I/usr/include -I/usr/include/libxml2 -I/usr/include/python3.5m -c bblfsh/pyuast.c -o build/temp.linux-x86_64-3.5/bblfsh/pyuast.o -std=c++11
    unable to execute 'g++': No such file or directory
    error: command 'g++' failed with exit status 1
`

2. Remove package dir deletion to avoid build error:
`rm: cannot remove 'package/vecino': Directory not empty
The command '/bin/sh -c pip3 install --no-cache-dir ./package && rm -rf package' returned a non-zero code: 1`
as some files in package/vecino are being used.