### PR TITLE
Revert "Skipping sign-off for organization members"

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
This reverts commit adf767c2d835e7fd0df327826f3ad2311e528946.

Source{d} members should sign commits anyway.

Signed-off-by: Konstantin Slavnov <kslavnov@gmail.com>

